### PR TITLE
Warning fix

### DIFF
--- a/6pack.c
+++ b/6pack.c
@@ -437,7 +437,7 @@ int benchmark_speed(int compress_level, const char* input_file)
   if(bytes_read != fsize)
   {
     printf("Error reading file %s!\n", shown_name);
-    printf("Read %d bytes, expecting %d bytes\n", bytes_read, fsize);
+    printf("Read %lu bytes, expecting %lu bytes\n", bytes_read, fsize);
     free(buffer);
     free(result);
     fclose(in);
@@ -632,5 +632,5 @@ int main(int argc, char** argv)
     return pack_file(compress_level, input_file, output_file);
 
   /* unreachable */
-  return 0;
+  //return 0;
 }

--- a/fastlz.h
+++ b/fastlz.h
@@ -30,10 +30,10 @@
 #define FASTLZ_VERSION 0x000100
 
 #define FASTLZ_VERSION_MAJOR     0
-#define FASTLZ_VERSION_MINOR     0
+#define FASTLZ_VERSION_MINOR     2
 #define FASTLZ_VERSION_REVISION  0
 
-#define FASTLZ_VERSION_STRING "0.1.0"
+#define FASTLZ_VERSION_STRING "0.2.0"
 
 #if defined (__cplusplus)
 extern "C" {
@@ -54,6 +54,12 @@ extern "C" {
 */
 
 int fastlz_compress(const void* input, int length, void* output);
+
+/**
+	Returns the size of the buffer needed for compression.
+	A utility method for call fastlz_compress().
+*/
+#define fastlz_compress_buffer_size(sz) (sz*9/8 > 66 ? sz*9/8 : 66)
 
 /**
   Decompress a block of compressed data and returns the size of the 


### PR DESCRIPTION
- Modification from this [fork](https://github.com/leethomason/FastLZ)
-  Fixed a warning that concerns the format in printf: '%d' was replaced by '%lu' 
- The unreachable last instruction is not necessary.
