### PR TITLE
Fix typos in block format documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,7 +66,7 @@ For more details, check the corresponding [GitHub Actions build logs](https://gi
 
 Let us assume that FastLZ compresses an array of bytes, called the _uncompressed block_, into another array of bytes, called the _compressed block_. To understand what will be stored in the compressed block, it is illustrative to demonstrate how FastLZ will _decompress_ the block to retrieve the original uncompressed block.
 
-The first 5-bit of the block, i.e. the 5 most-significant bits of the first byte, is the **block tag**. Currently the block tag determines the compression level used to produce the compressed block.
+The first 3-bit of the block, i.e. the 3 most-significant bits of the first byte, is the **block tag**. Currently the block tag determines the compression level used to produce the compressed block.
 
 |Block tag|Compression level|
 |---------|-----------------|
@@ -86,7 +86,7 @@ Each instruction starts with a 1-byte opcode, 2-byte opcode, or 3-byte opcode.
 |-----------|------------------|--------------------|--|
 | Literal run | `000`, L&#x2085;-L&#x2080; | -|- |
 | Short match | M&#x2082;-M&#x2080;, R&#x2081;&#x2082;-R&#x2088; | R&#x2087;-R&#x2080; | - |
-| Long match | `111`, R&#x2081;&#x2082;-R&#x2088; | M&#x2087;-R&#x2080; | R&#x2087;-R&#x2080; |
+| Long match | `111`, R&#x2081;&#x2082;-R&#x2088; | M&#x2087;-M&#x2080; | R&#x2087;-R&#x2080; |
 
 Note that the _very first_ instruction in a compressed block is always a literal run.
 


### PR DESCRIPTION
The block format documentation currently has two errors which are being corrected by this PR:

* The block tag only holds three bits, as we can see from https://github.com/ariya/FastLZ/blob/c3bdfad9e0094d0fb15c12cd300e647c13dc85f9/fastlz.c#L341 https://github.com/ariya/FastLZ/blob/c3bdfad9e0094d0fb15c12cd300e647c13dc85f9/fastlz.c#L487 https://github.com/ariya/FastLZ/blob/c3bdfad9e0094d0fb15c12cd300e647c13dc85f9/fastlz.c#L544 With the documented five bits, we would had overwritten the length of the first literal instruction.
* The variable for long matches has been invalid for `opcode[1]`. `opcode[1]` will hold `match_length - 9` only (with 9 being the shortest possible long match), not an (unknown) combination of match length and offset.